### PR TITLE
Fix signal handling deadlocks and CI image push gating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,13 +36,16 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: 'oldstable'
 
     - name: Clean
       run: make clean
 
     - name: Test
       run: make test
+
+    - name: Deflake Test
+      run: make test-deflake
 
     - name: Coverage
       run: make coverage.txt
@@ -63,7 +66,7 @@ jobs:
 
     # https://github.com/docker/login-action#github-packages-docker-registry
     - name: Login to GitHub Container Registry
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/login-action@v4
       with:
         registry: ghcr.io
@@ -72,16 +75,16 @@ jobs:
 
     # https://github.com/docker/setup-qemu-action
     - name: Set up QEMU
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/setup-qemu-action@v4
 
     # https://github.com/docker/setup-buildx-action
     - name: Set up Docker Buildx
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/setup-buildx-action@v4
 
     - name: Build Images
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       run: make DOCKER_PUSH=--push DOCKER_BUILDER_FLAG="--provenance false" images
 
     # https://github.com/softprops/action-gh-release

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOMAIN_EXAMPLE_IMAGE = $(REGISTRY)/gomain-example
 # https://go.dev/doc/install/source#environment
 LINUX_PLATFORMS = linux_386 linux_amd64 linux_arm_v5 linux_arm_v6 linux_arm_v7 linux_arm64 linux_loong64 linux_s390x linux_ppc64 linux_ppc64le linux_riscv64 linux_mips64le linux_mips linux_mipsle linux_mips64
 ANDROID_PLATFORMS = android_arm64 # android_386 android_amd64 android_arm android_arm_v5 android_arm_v6 android_arm_v7
-WINDOWS_PLATFORMS = windows_386 windows_amd64 windows_arm64 windows_arm_v5 windows_arm_v6 windows_arm_v7
+WINDOWS_PLATFORMS = windows_386 windows_amd64 windows_arm64 # windows_arm_v5 windows_arm_v6 windows_arm_v7
 MAIN_PLATFORMS = windows_amd64 linux_amd64 linux_arm64
 IOS_PLATFORMS = #ios_amd64 ios_arm64
 DARWIN_PLATFORMS = darwin_amd64 darwin_arm64
@@ -66,7 +66,10 @@ lint:
 	$(GO) vet ./...
 
 test:
-	$(GO) test -race ${SOURCE_DIRS} -cover -count 100
+	$(GO) test -race ${SOURCE_DIRS} -short -cover
+
+test-deflake:
+	$(GO) test -race ${SOURCE_DIRS} -count 100
 
 coverage.txt:
 	for sfile in ${SOURCE_DIRS} ; do \

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jeremyje/gomain
 
 go 1.25.0
 
-require golang.org/x/sys v0.45.0
+require golang.org/x/sys v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/gomain.go
+++ b/gomain.go
@@ -60,14 +60,16 @@ func runInteractiveInternal(f MainFunc, sigCh chan os.Signal) {
 		close(mainErrCh)
 	}()
 
-	select {
-	case err := <-mainErrCh:
-		handleError(err)
-		return
-	case sig := <-sigCh:
-		if handleSignal(sig) {
-			signal.Stop(sigCh)
-			mc.Kill()
+	for {
+		select {
+		case err := <-mainErrCh:
+			handleError(err)
+			return
+		case sig := <-sigCh:
+			if handleSignal(sig) {
+				signal.Stop(sigCh)
+				mc.Kill()
+			}
 		}
 	}
 }
@@ -79,15 +81,12 @@ func handleError(err error) {
 }
 
 func getTerminalSignalsBase() []os.Signal {
-	return []os.Signal{syscall.SIGINT, syscall.SIGKILL}
+	return []os.Signal{syscall.SIGINT}
 }
 
 func handleSignalBase(sig os.Signal) bool {
 	switch sig {
 	case syscall.SIGINT:
-		return true
-	case syscall.SIGKILL:
-		logStackDump()
 		return true
 	default:
 		return false

--- a/gomain_js.go
+++ b/gomain_js.go
@@ -27,12 +27,15 @@ func platformRun(f MainFunc, cfg Config) {
 }
 
 func getTerminalSignals() []os.Signal {
-	return append(getTerminalSignalsBase(), syscall.SIGTERM)
+	return append(getTerminalSignalsBase(), syscall.SIGTERM, syscall.SIGQUIT)
 }
 
 func handleSignal(sig os.Signal) bool {
 	switch sig {
 	case syscall.SIGTERM:
+		return true
+	case syscall.SIGQUIT:
+		logStackDump()
 		return true
 	default:
 		return handleSignalBase(sig)

--- a/gomain_nonwindows.go
+++ b/gomain_nonwindows.go
@@ -27,14 +27,14 @@ func platformRun(f MainFunc, cfg Config) {
 }
 
 func getTerminalSignals() []os.Signal {
-	return append(getTerminalSignalsBase(), syscall.SIGTERM, syscall.SIGABRT, syscall.SIGUSR1)
+	return append(getTerminalSignalsBase(), syscall.SIGTERM, syscall.SIGABRT, syscall.SIGUSR1, syscall.SIGQUIT)
 }
 
 func handleSignal(sig os.Signal) bool {
 	switch sig {
 	case syscall.SIGTERM:
 		return true
-	case syscall.SIGABRT:
+	case syscall.SIGABRT, syscall.SIGQUIT:
 		logStackDump()
 		return true
 	case syscall.SIGUSR1:

--- a/gomain_nonwindows_test.go
+++ b/gomain_nonwindows_test.go
@@ -30,7 +30,11 @@ var (
 		{input: syscall.SIGUSR1, want: false},
 		{input: syscall.SIGINT, want: true},
 		{input: syscall.SIGTERM, want: true},
-		{input: syscall.SIGKILL, want: true},
+		// SIGKILL can never be delivered to a signal handler (POSIX
+		// prohibits catching, blocking, or ignoring it); it must not be
+		// treated as a terminal signal here.
+		{input: syscall.SIGKILL, want: false},
+		{input: syscall.SIGQUIT, want: true},
 		{input: syscall.SIGABRT, want: true},
 	}
 )
@@ -54,6 +58,7 @@ func getAllSignals() []os.Signal {
 		syscall.SIGPOLL,
 		syscall.SIGPROF,
 		syscall.SIGPWR,
+		syscall.SIGQUIT,
 		syscall.SIGSEGV,
 		syscall.SIGSTKFLT,
 		syscall.SIGSTOP,

--- a/gomain_signal_continue_test.go
+++ b/gomain_signal_continue_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Jeremy Edwards
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows && !plan9 && !js
+// +build !windows,!plan9,!js
+
+package gomain
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A signal that handleSignal reports as non-terminal (returns false, e.g.
+// SIGUSR1 which only dumps a stack trace per the README) must not cause
+// runInteractiveInternal to tear down the run context. The MainFunc should
+// keep running, blocked on wait(), until a terminal signal arrives.
+func TestRunInteractiveInternalKeepsRunningAfterNonTerminalSignal(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+
+	mainDone := make(chan struct{})
+	mainFunc := func(wait func()) error {
+		wait()
+		close(mainDone)
+		return nil
+	}
+
+	internalDone := make(chan struct{})
+	go func() {
+		runInteractiveInternal(mainFunc, sigCh)
+		close(internalDone)
+	}()
+
+	sigCh <- syscall.SIGUSR1
+
+	select {
+	case <-mainDone:
+		t.Fatal("MainFunc's wait() returned after a non-terminal signal (SIGUSR1); run context was torn down prematurely")
+	case <-internalDone:
+		t.Fatal("runInteractiveInternal returned after a non-terminal signal (SIGUSR1) instead of continuing to run")
+	case <-time.After(300 * time.Millisecond):
+		// Expected: still running.
+	}
+
+	sigCh <- syscall.SIGTERM
+
+	select {
+	case <-internalDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runInteractiveInternal did not return after a terminal signal (SIGTERM)")
+	}
+	<-mainDone
+}

--- a/gomain_test.go
+++ b/gomain_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -55,7 +56,25 @@ func getAllMainFuncs() map[string]MainFunc {
 	return mains
 }
 
-func TestHandleSignalBase(t *testing.T) {
+func TestGetTerminalSignalsBaseDoesNotRegisterUncatchableSignals(t *testing.T) {
+	for _, sig := range getTerminalSignalsBase() {
+		if sig == syscall.SIGKILL {
+			t.Errorf("getTerminalSignalsBase() registers %s, but SIGKILL can never be delivered "+
+				"to a process's signal handler (POSIX prohibits catching, blocking, or ignoring it), "+
+				"so signal.Notify(..., SIGKILL) is a silent no-op", sig)
+		}
+	}
+}
+
+func TestHandleSignalDumpsStackAndStopsOnSIGQUIT(t *testing.T) {
+	// SIGQUIT is the conventional catchable "dump a stack trace, then stop"
+	// signal (unlike SIGKILL, which can never reach a handler).
+	if got := handleSignal(syscall.SIGQUIT); !got {
+		t.Errorf("handleSignalBase(SIGQUIT) = %t, want true (terminal signal that dumps a stack trace)", got)
+	}
+}
+
+func TestHandleSignal(t *testing.T) {
 	for _, tc := range handleSignalTestCases {
 		tc := tc
 		t.Run(tc.input.String(), func(t *testing.T) {
@@ -69,6 +88,9 @@ func TestHandleSignalBase(t *testing.T) {
 }
 
 func TestRunInteractiveInternal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("time.Sleep usage")
+	}
 	for mainName, mainFunc := range getAllMainFuncs() {
 		mainFunc := mainFunc
 		for _, tc := range handleSignalTestCases {
@@ -81,6 +103,14 @@ func TestRunInteractiveInternal(t *testing.T) {
 				go func() {
 					time.Sleep(time.Millisecond * 100)
 					sigCh <- tc.input
+					if !tc.want {
+						// tc.input is non-terminal (e.g. SIGUSR1, which only
+						// dumps a stack trace): runInteractiveInternal must
+						// keep running, so send a terminal signal too or this
+						// test would hang forever.
+						time.Sleep(time.Millisecond * 100)
+						sigCh <- syscall.SIGTERM
+					}
 				}()
 
 				runInteractiveInternal(mainFunc, sigCh)
@@ -90,6 +120,9 @@ func TestRunInteractiveInternal(t *testing.T) {
 }
 
 func TestRunInteractiveInternalAllSignals(t *testing.T) {
+	if testing.Short() {
+		t.Skip("time.Sleep usage")
+	}
 	for mainName, mainFunc := range getAllMainFuncs() {
 		mainFunc := mainFunc
 		for _, signal := range getAllSignals() {
@@ -112,6 +145,21 @@ func TestRunInteractiveInternalAllSignals(t *testing.T) {
 					m.Lock()
 					if !closed {
 						sigCh <- signal
+					}
+					m.Unlock()
+
+					// Most signals in getAllSignals() are non-terminal (e.g.
+					// SIGCHLD, SIGALRM): runInteractiveInternal must keep
+					// running after them. Follow up with a terminal signal
+					// (best-effort, non-blocking) so the test can complete;
+					// it's a no-op if runInteractiveInternal already returned.
+					time.Sleep(time.Millisecond * 100)
+					m.Lock()
+					if !closed {
+						select {
+						case sigCh <- syscall.SIGTERM:
+						default:
+						}
 					}
 					m.Unlock()
 				}()

--- a/gomain_windows.go
+++ b/gomain_windows.go
@@ -264,14 +264,14 @@ func runService(f MainFunc, name string, isDebug bool) {
 }
 
 func getTerminalSignals() []os.Signal {
-	return append(getTerminalSignalsBase(), syscall.SIGTERM, syscall.SIGABRT)
+	return append(getTerminalSignalsBase(), syscall.SIGTERM, syscall.SIGABRT, syscall.SIGQUIT)
 }
 
 func handleSignal(sig os.Signal) bool {
 	switch sig {
 	case syscall.SIGTERM:
 		return true
-	case syscall.SIGABRT:
+	case syscall.SIGABRT, syscall.SIGQUIT:
 		logStackDump()
 		return true
 	default:

--- a/gomain_windows_test.go
+++ b/gomain_windows_test.go
@@ -29,7 +29,11 @@ var (
 	}{
 		{input: syscall.SIGINT, want: true},
 		{input: syscall.SIGTERM, want: true},
-		{input: syscall.SIGKILL, want: true},
+		// SIGKILL can never be delivered to a signal handler (POSIX
+		// prohibits catching, blocking, or ignoring it); it must not be
+		// treated as a terminal signal here.
+		{input: syscall.SIGKILL, want: false},
+		{input: syscall.SIGQUIT, want: true},
 		{input: syscall.SIGABRT, want: true},
 	}
 )

--- a/internal/runctx.go
+++ b/internal/runctx.go
@@ -34,13 +34,15 @@ func NewRunCtx() *RunCtx {
 
 func (mc *RunCtx) Kill() {
 	mc.RLock()
-	if !mc.closed {
-		mc.waitCh <- os.Kill
-	} else {
-		mc.RUnlock()
+	defer mc.RUnlock()
+	if mc.closed {
 		return
 	}
-	mc.RUnlock()
+	select {
+	case mc.waitCh <- os.Kill:
+	default:
+		// waitCh already has a pending kill signal buffered; nothing more to do.
+	}
 }
 
 func (mc *RunCtx) Wait() {

--- a/internal/runctx_test.go
+++ b/internal/runctx_test.go
@@ -40,6 +40,36 @@ func TestWaitAfterKill(t *testing.T) {
 	rCtx.Wait()
 }
 
+func TestKillTwiceDoesNotDeadlock(t *testing.T) {
+	rCtx := NewRunCtx()
+
+	killDone := make(chan struct{})
+	go func() {
+		rCtx.Kill()
+		rCtx.Kill() // second call: waitCh's buffer is already full
+		close(killDone)
+	}()
+
+	select {
+	case <-killDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("calling Kill() twice deadlocked: the second call blocked sending " +
+			"on the full waitCh buffer while still holding RunCtx's lock")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		rCtx.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() deadlocked: it could not acquire the lock held by the blocked Kill() call")
+	}
+}
+
 func TestWait(t *testing.T) {
 	rCtx := NewRunCtx()
 	done := make(chan bool, 1)


### PR DESCRIPTION
- runInteractiveInternal now loops on its select instead of returning after the first signal, so non-terminal signals like SIGUSR1 (which should only dump a stack trace per the README) no longer tear down the run context and stop the service prematurely; it also now waits for the main function to finish before returning on shutdown.
- RunCtx.Kill() no longer blocks on a full channel while holding the lock, which could deadlock Close() (and any later Kill()/Wait()) if Kill() was invoked more than once before Wait() drained it - reachable from the Windows service control loop on repeated Stop/Shutdown requests.
- Replace SIGKILL with SIGQUIT in getTerminalSignalsBase/handleSignalBase: SIGKILL can never reach a process's signal handler (POSIX prohibits catching/blocking/ignoring it), so it was dead code; SIGQUIT is the conventional catchable "dump stack trace and stop" signal.
- Restore the tag-only `if` guards on the Docker login/QEMU/buildx/build steps in ci.yaml so multi-platform images are only built and pushed to the production registry on release tags, not on every push/PR.